### PR TITLE
Support filtering with multiple service IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Added support to filter by service ID(s) using comma separated list
 
 ### Changed
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -13,10 +13,11 @@ Paste the key into the `API Key` configuration field for the PagerDuty datasourc
 Add an annotation to a dashboard normally, selecting the PagerDuty datasource. There are a few filters available to
 limit the number of results, or the scope.
 
-### Filter by service ID (optional)
+### Filter by service ID(s) (optional)
 * A PagerDuty service represents something you monitor (like a web service, email service, or database service). It is a
   container for related incidents that associates them with escalation policies. Documentation is available
-[here](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/get_services)
+[here](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/get_services).  You can use the
+  `Service ID` field to filter by specific service IDs in a comma separated list. For example, `S12345,S23456`.
 
 ### Filter by urgency (optional)
 * [Urgencies](https://support.pagerduty.com/docs/service-settings#section-enable-urgencies) is a feature which allows you to customize how your team is notified based on the criticality of an incident: incidents can be either high-urgency (requires immediate attention) or low-urgency (it can wait).

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -71,11 +71,12 @@ export class GenericDatasource {
     queryString += `&limit=${limit}`;
 
     if (options.annotation) {
-    
+
       const annotation = options.annotation
 
       if (annotation.serviceId) {
-        queryString += "&service_ids%5B%5D=" + annotation.serviceId;
+        var array = annotation.serviceId.split(',');
+        queryString += "&service_ids%5B%5D=" + array.join('&service_ids%5B%5D=');
       }
 
       if (annotation.urgency) {
@@ -84,7 +85,7 @@ export class GenericDatasource {
 
       if (annotation.status) {
         queryString += "&statuses%5B%5D=" + annotation.status;
-      }    
+      }
     }
 
     return this.getEvents([], queryString, 0, limit, options);


### PR DESCRIPTION
Not sure on the contribution guidelines so gave it a decent college try.

The incidents api: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEzOA-list-incidents

```
service_ids[]
array[string]
Returns only the incidents associated with the passed service(s). This expects one or more service IDs.
```